### PR TITLE
Add: config-version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -4,6 +4,7 @@
 # name or the intended use of these models
 name: 'rudder_events_registry'
 version: '1.0.0'
+config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
 profile: 'default'


### PR DESCRIPTION
Add `config-version: 2` to [dbt_project.yml](https://github.com/rudderlabs/dbt-events-registry/blob/master/dbt_project.yml).

> Without this configuration, dbt will assume your dbt_project.yml uses the version 1 syntax, which was deprecated in dbt v0.19.0.
https://docs.getdbt.com/reference/project-configs/config-version#default